### PR TITLE
Use @mixin for behaviors

### DIFF
--- a/gii/modelDoc/ModelDocCode.php
+++ b/gii/modelDoc/ModelDocCode.php
@@ -12,7 +12,7 @@
 class ModelDocCode extends CCodeModel
 {
     /**
-     * @var
+     * @var string
      */
     public $modelClass;
 
@@ -22,9 +22,14 @@ class ModelDocCode extends CCodeModel
     public $modelPath = 'application.models';
 
     /**
-     * @var
+     * @var int
      */
     public $addModelMethodDoc;
+
+    /**
+     * @var int
+     */
+    public $useMixin;
 
     /**
      * @var string
@@ -47,8 +52,8 @@ class ModelDocCode extends CCodeModel
             array('modelPath', 'match', 'pattern' => '/^(\w+[\w\.]*|\*?|\w+\.\*)$/', 'message' => '{attribute} should only contain word characters, dots, and an optional ending asterisk.'),
             array('modelClass', 'match', 'pattern' => '/^[a-zA-Z_]\w*$/', 'message' => '{attribute} should only contain word characters.'),
             array('modelPath', 'validateModelPath', 'skipOnError' => true),
-            array('modelPath', 'sticky'),
-            array('addModelMethodDoc', 'numerical', 'integerOnly' => true),
+            array('modelPath,addModelMethodDoc,useMixin', 'sticky'),
+            array('addModelMethodDoc,useMixin', 'numerical', 'integerOnly' => true),
         ));
     }
 
@@ -60,6 +65,7 @@ class ModelDocCode extends CCodeModel
         return array_merge(parent::attributeLabels(), array(
             'modelPath' => 'Model Path',
             'modelClass' => 'Model Class',
+            'useMixin' => 'Use @mixin doc for behaviors'
         ));
     }
 
@@ -180,7 +186,7 @@ class ModelDocCode extends CCodeModel
     }
 
     /**
-     * @param $modelName
+     * @param $modelClass
      * @param $behavior
      * @param array $ignoreMethods
      * @return array
@@ -204,7 +210,7 @@ class ModelDocCode extends CCodeModel
             $methodReturn = $this->getTypeFromDocComment($behavior, $methodName, 'return');
             $paramTypes = $this->getDocComment($behavior, $methodName, 'param');
             $methodReturn = $methodReturn ? current($methodReturn) . ' ' : '';
-            $property = " * @method $methodReturn $methodName(";
+            $property = " * @method {$methodReturn}{$methodName}(";
             $r = new ReflectionMethod($behavior, $methodName);
             $params = $r->getParameters();
             $separator = '';

--- a/gii/modelDoc/templates/default/model.php
+++ b/gii/modelDoc/templates/default/model.php
@@ -71,22 +71,30 @@ $properties[] = " *";
 // behaviors
 $behaviors = $model->behaviors();
 if ($behaviors) {
-    $behaviorMethods = array();
-    foreach (get_class_methods('CActiveRecordBehavior') as $methodName)
-        $behaviorMethods[$methodName] = $methodName;
-    $behaviorProperties = array();
-    foreach (get_class_vars('CActiveRecordBehavior') as $propertyName)
-        $behaviorProperties[$propertyName] = $propertyName;
+    if ($this->useMixin) {
+        foreach ($behaviors as $behavior) {
+            $properties[] = ' * @mixin ' . $this->getBehaviorClass($behavior);
+        }
+        $properties[] = ' *';
+    } else {
+        $behaviorMethods = array();
+        foreach (get_class_methods('CActiveRecordBehavior') as $methodName)
+            $behaviorMethods[$methodName] = $methodName;
+        $behaviorProperties = array();
+        foreach (get_class_vars('CActiveRecordBehavior') as $propertyName)
+            $behaviorProperties[$propertyName] = $propertyName;
 
-    foreach ($behaviors as $behavior) {
-        $behavior = $this->getBehaviorClass($behavior);
-        $behaviorProperties = $this->getBehaviorProperties($modelClass, $behavior, CMap::mergeArray($behaviorMethods, $selfMethods), CMap::mergeArray($behaviorProperties, $selfProperties));
-        if ($behaviorProperties) {
-            $properties[] = ' * @see ' . $behavior;
-            foreach ($behaviorProperties as $behaviorProperty) {
-                $properties[] = $behaviorProperty;
+        foreach ($behaviors as $behavior) {
+            $behavior = $this->getBehaviorClass($behavior);
+
+            $behaviorProperties = $this->getBehaviorProperties($modelClass, $behavior, CMap::mergeArray($behaviorMethods, $selfMethods), CMap::mergeArray($behaviorProperties, $selfProperties));
+            if ($behaviorProperties) {
+                $properties[] = ' * @see ' . $behavior;
+                foreach ($behaviorProperties as $behaviorProperty) {
+                    $properties[] = $behaviorProperty;
+                }
+                $properties[] = ' *';
             }
-            $properties[] = ' *';
         }
     }
 }

--- a/gii/modelDoc/views/index.php
+++ b/gii/modelDoc/views/index.php
@@ -41,5 +41,13 @@ $class = get_class($model);
     </div>
     <?php echo $form->error($model, 'addModelMethodDoc'); ?>
 </div>
+<div class="row checkbox">
+	<?php echo $form->label($model, 'useMixin'); ?>
+	<?php echo $form->checkbox($model, 'useMixin'); ?>
+	<div class="tooltip">
+		Use @mixin doc for behaviors.
+	</div>
+	<?php echo $form->error($model, 'useMixin'); ?>
+</div>
 
 <?php $this->endWidget(); ?>


### PR DESCRIPTION
PhpStorm since version 7.1 supports `@mixin` phpdoc tag. This feature added as checkbox.
Read more at http://blog.jetbrains.com/phpstorm/2013/11/phpstorm-7-1-eap-133-51/

Additional changes:
- Make `addModelMethodDoc` property sticky.
- Fixed few phpdocs in code.
