### PR TITLE
refresh database schema before generation

### DIFF
--- a/gii/modelDoc/templates/default/model.php
+++ b/gii/modelDoc/templates/default/model.php
@@ -15,6 +15,11 @@
  */
 $properties = array(' *');
 
+// refresh model table schema
+Yii::app()->db->getSchema()->refresh();
+$model->refreshMetaData();
+$model->refresh();
+
 // get own methods and properties
 $modelClass = $reflection->getShortName();
 if (!$reflection->inNamespace())


### PR DESCRIPTION
if tables are altered directly in Database Yii cache of database schema might not reflect database changes. This change refreshes the schema cache of Yii.
