### PR TITLE
Use reflection to detect ActiveRecord

### DIFF
--- a/gii/modelDoc/ModelDocCode.php
+++ b/gii/modelDoc/ModelDocCode.php
@@ -162,6 +162,8 @@ class ModelDocCode extends CCodeModel
             $reflectedClass = new ReflectionClass($modelClass);
             if ($reflectedClass->isInstantiable() === false)
                 continue; //continue if this class is not instantiable
+            if (!$reflectedClass->isSubclassOf(CActiveRecord::class))
+                continue;
 
             // load the model
             try {
@@ -169,7 +171,7 @@ class ModelDocCode extends CCodeModel
             } catch (Exception $e) {
                 $model = null;
             }
-            if (!$model || !is_subclass_of($model, 'CActiveRecord'))
+            if ($model === null)
                 continue;
 
             // everything passes, add it to the list


### PR DESCRIPTION
Updated the file detection code to use the existing reflection object to determine if a class is actually a CActiveRecord before constructing it. This saves some overhead in constructing models, and more importantly it avoids uncatchable fatal errors in php5 if one of the classes has required parameters in it's constructor.